### PR TITLE
add support for new pageview_complete format

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ download_jobs(wp_yyyymmdd, wd_yyyymmdd, data_path=data_path, jobs_to_download=jo
 
 Any of the jobs listed in the status report above can be specified in the `jobs_to_download` kwarg. In addition, there are two special job strings,
 
-* `pagecounts`: used to download monthly pageviews (e.g. `pagecounts-2020-09-views-ge-5-totals.bz2`)
+* `pageviewcomplete`: used to download monthly pageviews (e.g. `pageviews-20200901-user.bz2`)
 * `wikidata`: used to download Wikidata json dumps (e.g. `wikidata-20200921-all.json.bz2`)
 
 

--- a/kwnlp_dump_downloader/__init__.py
+++ b/kwnlp_dump_downloader/__init__.py
@@ -1,5 +1,5 @@
 # Copyright 2020-present Kensho Technologies, LLC.
-__version__ = "0.0.3"
+__version__ = "0.1.0"
 
 from kwnlp_dump_downloader.downloader import download_jobs
 from kwnlp_dump_downloader.dump_status import WdsFile

--- a/kwnlp_dump_downloader/argconfig.py
+++ b/kwnlp_dump_downloader/argconfig.py
@@ -7,7 +7,7 @@ DEFAULT_KWNLP_DATA_PATH: str = ""
 DEFAULT_KWNLP_WIKI_MIRROR_URL: str = "https://dumps.wikimedia.org"
 DEFAULT_KWNLP_WIKI: str = "enwiki"
 DEFAULT_KWNLP_DOWNLOAD_JOBS: str = (
-    "pagecounts,pagetable,pagepropstable,redirecttable,articlesdump,wikidata"
+    "pageviewcomplete,pagetable,pagepropstable,redirecttable,articlesdump,wikidata"
 )
 DEFAULT_KWNLP_LOGGING_LEVEL: int = logging.INFO
 

--- a/kwnlp_dump_downloader/cli_download_jobs.py
+++ b/kwnlp_dump_downloader/cli_download_jobs.py
@@ -34,3 +34,7 @@ def main() -> None:
         wiki=args.wiki,
         jobs_to_download=jobs_to_download,
     )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In September/October 2020 the pageview dumps changed format. See 

https://dumps.wikimedia.org/other/pageview_complete/readme.html

and 

https://lists.wikimedia.org/pipermail/wikitech-l/2020-October/093935.html

This version supports downloading the daily views. Eventually Wikimedia will make monthly roll ups available and we will update the downloader again. 